### PR TITLE
Added option to disable Scriptable Singleton Asset Creator

### DIFF
--- a/Editor/DefineRegistrant.cs
+++ b/Editor/DefineRegistrant.cs
@@ -1,0 +1,38 @@
+// This script should only run when define manager is installed
+#if ENABLE_DEFINE_MANAGER
+
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Hibzz.DefineManager;
+
+namespace Hibzz.Singletons.Editor
+{
+    /// <summary>
+    /// Used to register the defines
+    /// </summary>
+    internal class DefineRegistrant
+    {
+        [RegisterDefine]
+        static DefineRegistrationData RegisterDisableScriptableObjectCreator()
+        {
+            DefineRegistrationData data = new DefineRegistrationData();
+
+            data.Define = "DISABLE_SCRIPTABLE_SINGLETON_CREATOR";
+            data.DisplayName = "Disable Scriptable Singleton Creator";
+            data.Category = "Hibzz.Singletons";
+            data.Description = "The scriptable singleton creator functionality " +
+                "lets users mark any ScriptableSingleton class with an attribute " +
+                "called `CreateScriptableSingletonAsset`. When the user presses " +
+                "the \"Create Scriptable Singleton Assets\" button, the system " +
+                "will create any missing assets for those singletons in the " +
+                "\"Resources/Singletons\" folder. \n\n" + 
+                "Installing this define will disable this feature.";
+            data.EnableByDefault = false;
+
+            return data;
+        }
+    }
+}
+
+#endif

--- a/Editor/DefineRegistrant.cs.meta
+++ b/Editor/DefineRegistrant.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5d102ff7287dff5428ec3eefcfeabc60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/SingletonsEditor.cs
+++ b/Editor/SingletonsEditor.cs
@@ -9,7 +9,9 @@ namespace Hibzz.Singletons.Editor
     {
         // These are menu paths
         const string BASE_PATH = "Hibzz/Singletons/";
-        const string CREATE_SINGLETON_ASSET_PATH = BASE_PATH + "Create Scriptable Singleton Assets";
+
+        #region Scriptable Singleton Asset Creator Code
+        #if !DISABLE_SCRIPTABLE_SINGLETON_CREATOR // when feature isn't disabled
 
         // these are debug logs made into consts
         #region Debug Logs
@@ -20,6 +22,9 @@ namespace Hibzz.Singletons.Editor
             "  Please use <i>CreateScriptableSingletonAsset</i> attribute to use this functionality. \n";
 
         #endregion
+        
+
+        const string CREATE_SINGLETON_ASSET_PATH = BASE_PATH + "Create Scriptable Singleton Assets";
 
         /// <summary>
         /// Create ScriptableSingleton assets for all classes that has a 
@@ -94,6 +99,9 @@ namespace Hibzz.Singletons.Editor
             // return true indicating that the process was successful
             return true;
         }
+
+        #endif
+        #endregion
     }
 }
 

--- a/Editor/com.hibzz.singletons.editor.asmdef
+++ b/Editor/com.hibzz.singletons.editor.asmdef
@@ -2,7 +2,8 @@
     "name": "com.hibzz.singletons.editor",
     "rootNamespace": "Hibzz.Singletons.Editor",
     "references": [
-        "GUID:b2fef9eae29790340a713d8578864b00"
+        "GUID:b2fef9eae29790340a713d8578864b00",
+        "GUID:b844f493a2cd07b4cbf81917a23ac063"
     ],
     "includePlatforms": [
         "Editor"

--- a/Scripts/Attributes/CreateScriptableSingletonAssetAttribute.cs
+++ b/Scripts/Attributes/CreateScriptableSingletonAssetAttribute.cs
@@ -1,9 +1,11 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
+
+// as long as the scriptable singleton asset creator isn't disabled
+#if !DISABLE_SCRIPTABLE_SINGLETON_CREATOR
 
 namespace Hibzz.Singletons
 {
     public class CreateScriptableSingletonAssetAttribute : Attribute { }
 }
+
+#endif


### PR DESCRIPTION
This update adds functionality and gives the user the option to disable the newly added `Scriptable Singleton Asset Creator` from the library if the user adds the define `DISABLE_SCRIPTABLE_SINGLETON_CREATOR` to Unity.

It neatly integrates with one of our other packages called Define Manager. Please install [Define Manager](https://github.com/hibzzgames/Hibzz.DefineManager) to install/remove defines across different packages with ease.