### PR TITLE
Adding support for Singletons in the Editor context

### DIFF
--- a/Scripts/Core/Singleton.cs
+++ b/Scripts/Core/Singleton.cs
@@ -1,83 +1,85 @@
 using System;
+using System.Collections.Generic;
 using System.Reflection;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace Hibzz.Singletons
 {
-	public class Singleton<T> : MonoBehaviour where T : Component
-	{
-		private static T instance;
+    public class Singleton<T> : MonoBehaviour where T : Component
+    {
+        private static T instance;
 
-		/// <summary>
-		/// Gives a reference to the singleton instance. If none is available, 
-		/// creates a new one and returns it
-		/// </summary>
-		public static T Instance
-		{
-			get
-			{
-				if (instance == null)
-				{
-					instance = RequestNewInstance();
-				}
+        /// <summary>
+        /// Gives a reference to the singleton instance. If none is available, 
+        /// creates a new one and returns it
+        /// </summary>
+        public static T Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    instance = RequestNewInstance();
+                }
 
-				return instance;
-			}
-		}
+                return instance;
+            }
+        }
 
-		/// <summary>
-		/// Gives any available singleton instance. 
-		/// If none was created or if one was destroyed, returns null.
-		/// </summary>
-		public static T AvailableInstance => instance;
+        /// <summary>
+        /// Gives any available singleton instance. 
+        /// If none was created or if one was destroyed, returns null.
+        /// </summary>
+        public static T AvailableInstance => instance;
 
-		// Used to create a new instance of the singleton
-		private static T RequestNewInstance()
-		{
-			T[] items = FindObjectsOfType<T>();
-			if (items.Length == 0)
-			{
-				// Using the reflection system, look if CreateNewInstance is being overriden
-				Type type = typeof(T);
-				MethodInfo method = type.GetMethod("CreateNewInstance", BindingFlags.NonPublic | BindingFlags.Static);
+        // Used to create a new instance of the singleton
+        private static T RequestNewInstance()
+        {
+            T[] items = FindObjectsOfType<T>();
+            if (items.Length == 0)
+            {
+                // Using the reflection system, look if CreateNewInstance is being overriden
+                Type type = typeof(T);
+                MethodInfo method = type.GetMethod("CreateNewInstance", BindingFlags.NonPublic | BindingFlags.Static);
 
-				// If the reflection system can find an overriden version of the static function CreateNewInstance, then invoke it
-				if(method is not null) 
-				{
-					return (T) method.Invoke(null, null);
-				}
+                // If the reflection system can find an overriden version of the static function CreateNewInstance, then invoke it
+                if(method is not null) 
+                {
+                    return (T) method.Invoke(null, null);
+                }
 
-				// No overrides found, call base implementation
-				return CreateNewInstance();
-			}
-			else if (items.Length > 1)
-			{
-				// more than one instance found. So returning null
-				Debug.LogError("Multiple instances of the singleton found. So, cant determine what's the singleton. Returning null.");
-				return null;
-			}
+                // No overrides found, call base implementation
+                return CreateNewInstance();
+            }
+            else if (items.Length > 1)
+            {
+                // more than one instance found. So returning null
+                Debug.LogError("Multiple instances of the singleton found. So, cant determine what's the singleton. Returning null.");
+                return null;
+            }
 
-			// only one instance of type T found in the scene
-			return items[0];
-		}
+            // only one instance of type T found in the scene
+            return items[0];
+        }
 
-		// Overridable function used to create custom instance creation if needed
-		protected static T CreateNewInstance()
-		{
-			GameObject obj = new GameObject();
-			obj.name = typeof(T).Name + "Object";
-			return obj.AddComponent<T>();
-		}
+        // Overridable function used to create custom instance creation if needed
+        protected static T CreateNewInstance()
+        {
+            GameObject obj = new GameObject();
+            obj.name = typeof(T).Name + "Object";
+            return obj.AddComponent<T>();
+        }
 
-		// when the singleton object gets destroyed, we make sure that the
-		// static singleton reference is cleared
-		protected virtual void OnDestroy()
-		{
-			// making sure that this object is the static instance, before just 
-			if (instance == this)
-			{
-				instance = null;
-			}
-		}
-	}
+        // when the singleton object gets destroyed, we make sure that the
+        // static singleton reference is cleared
+        protected virtual void OnDestroy()
+        {
+            // making sure that this object is the static instance, before just 
+            if (instance == this)
+            {
+                instance = null;
+            }
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hibzz.singletons",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "displayName": "hibzz.singletons",
   "description": "A library of singletons for Unity",
   "author": {


### PR DESCRIPTION
### Summary
This pull request targets a very specific use case to support singletons that exist in the editor context.

### Context 
As I was working on an editor tool, I realized that the `FindObjectsOfType<T>` function provided by Unity doesn't work as expected and always returns an empty array when not in play mode. This is not an issue for most use cases, but components with the attribute `[ExecuteAlways]` that run in the editor context have an issue and would create a new instance every time the domain reloads.

### How does the fix work?
This fix adds a custom function, a more expensive version, that behaves exactly like `FindObjectsOfType<T>` and works in the editor context by looking at every root object in the current scene and its children. Rest assured, the system is smart enough to use the regular, cheap function when in play mode and completely strips out this expensive function when the project is built.