### PR TITLE
Adding support to look for GameObjects with the don't save flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hibzz.singletons",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "displayName": "hibzz.singletons",
   "description": "A library of singletons for Unity",
   "author": {


### PR DESCRIPTION
### Summary
This pull request adds support for finding GameObjects with the don't save flag (such as temporary editor singletons added to a scene).

### Context
I kind of overlooked a key element in my previous update which are Singletons whose objects are tagged with the `[DontSave]` attribute. Since these objects do not get saved to the scene, many of the familiar APIs do not work. 

### Solution
In the end, it was `Resources.FindObjectsOfTypeAll<T>` that seems to work, however, I remember having issues with it before, such as picking prefabs and such. The solution was a new editor utility that I came across, `EditorUtility.IsPersistent(gameobject)`. This lets the caller know if the gameobject is saved to the disk (like most prefabs) or to the scene (like editor-only temporary singletons).

I have tested to a significant degree, but not to an exhaustive amount. So, please let me know if any bugs occur.