### PR TITLE
Adding Support for [StaticAccess] Attribute

### DIFF
--- a/Editor/DefineRegistrant.cs
+++ b/Editor/DefineRegistrant.cs
@@ -13,6 +13,8 @@ namespace Hibzz.Singletons.Editor
     /// </summary>
     internal class DefineRegistrant
     {
+        const string Category = "Hibzz.Singletons";
+
         [RegisterDefine]
         static DefineRegistrationData RegisterDisableScriptableObjectCreator()
         {
@@ -20,7 +22,8 @@ namespace Hibzz.Singletons.Editor
 
             data.Define = "DISABLE_SCRIPTABLE_SINGLETON_CREATOR";
             data.DisplayName = "Disable Scriptable Singleton Creator";
-            data.Category = "Hibzz.Singletons";
+            data.Category = Category;
+            data.EnableByDefault = false;
             data.Description = "The scriptable singleton creator functionality " +
                 "lets users mark any ScriptableSingleton class with an attribute " +
                 "called `CreateScriptableSingletonAsset`. When the user presses " +
@@ -28,7 +31,25 @@ namespace Hibzz.Singletons.Editor
                 "will create any missing assets for those singletons in the " +
                 "\"Resources/Singletons\" folder. \n\n" + 
                 "Installing this define will disable this feature.";
+
+            return data;
+        }
+
+        [RegisterDefine]
+        static DefineRegistrationData RegisterDisablePublicStaticAccessor()
+        {
+            DefineRegistrationData data = new DefineRegistrationData();
+
+            data.Define = "DISABLE_SINGLETON_AUTO_PUBLIC_STATIC_ACCESSOR";
+            data.DisplayName = "Disable Public Static Accessor";
+            data.Category = Category;
             data.EnableByDefault = false;
+            data.Description = "The singletons package offers a system to " +
+                "automatically generate public static accessors for items " +
+                "inside a partial singleton class when marked with a " +
+                "[StaticAccess] attribute. This is done using dynamic code " +
+                "generation.\n\n " +
+                "Installing this define will disable this feature.";
 
             return data;
         }

--- a/Editor/StaticAccess.cs
+++ b/Editor/StaticAccess.cs
@@ -1,0 +1,294 @@
+using System;
+using System.IO;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace Hibzz.Singletons.Editor
+{
+    public class StaticAccess : AssetPostprocessor
+    {
+        // gets a notification after all asset has been imported
+        private static void OnPostprocessAllAssets(
+            string[] importedAssets,
+            string[] deletedAssets,
+            string[] movedAssets,
+            string[] movedFromAssetPaths
+            )
+        {
+            // flag that indicates if code has been generated
+            bool codeGenerated = false;
+
+            // generate code for each imported asset if it's valid
+            foreach (var importedAsset in importedAssets)
+            {
+                if (TryGenerateCode(importedAsset))
+                {
+                    codeGenerated = true;
+                }
+            }
+
+            // reload assembly if code was generated (or removed)
+            if (codeGenerated)
+            {
+                AssetDatabase.Refresh();
+            }
+        }
+
+        /// <summary>
+        /// Tries to generate any singleton related code for the given asset
+        /// </summary>
+        /// <param name="assetPath">The path to the script asset to analyze and generate code for</param>
+        /// <returns>Was some code generated for the given asset?</returns>
+        private static bool TryGenerateCode(string assetPath)
+        {
+            // if the changed asset is not a script file, we don't care
+            if (!assetPath.EndsWith(".cs")) { return false; }
+
+            // Issue: For now this is okay, but in the future this decision will cause issues,
+            // for example what happens the user generates a singleton script that has the static
+            // access attribute in it? The system will see that the file name contains the common
+            // convention of .generated.cs so it'll ignore it. Alternatively we generate files
+            // that end with .staticaccess.generated.cs but that's too long. We'll cross that
+            // bridge when the time comes, but just jotting this down so it's easier to understand
+            // the issue later.
+
+            // if the generated script file is a generated script file, we don't care either
+            if (assetPath.EndsWith(".generated.cs")) { return false; }
+
+            // load the asset from the given path as a monoscript
+            var monoScript = AssetDatabase.LoadAssetAtPath<MonoScript>(assetPath);
+            if (monoScript is null) { return false; }
+
+            // make sure that they one of the variants of the singleton classes provided
+            var classType = monoScript.GetClass();
+            if (classType is null) { return false; }
+            if (!classType.IsASingletonVariant()) { return false; }
+
+            // don't generate code for abstract classes
+            if (classType.IsAbstract) { return false; }
+
+            // whether we generate some new content or not, we are going to need the path to the
+            // expected generated asset... at the end of this process we either create a new one,
+            // or check and delete an existing one
+            string generatedAssetPath = assetPath;
+            generatedAssetPath = generatedAssetPath.Substring(0, generatedAssetPath.LastIndexOf(".cs"));
+            generatedAssetPath += ".generated.cs";
+
+            // Now we need to generate the script file
+            if (GetGeneratedCode(classType, out string code))
+            {
+                File.WriteAllText(generatedAssetPath, code);
+            }
+            else 
+            {
+                // no code was generated, so remove any existing generated file
+                if(!File.Exists(generatedAssetPath)) { return false; }
+                File.Delete(generatedAssetPath);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Get the generated code from the given type
+        /// </summary>
+        /// <param name="classType">The type to analyze</param>
+        /// <param name="code">The generated code as a string</param>
+        /// <returns>Was code generated as a string</returns>
+        private static bool GetGeneratedCode(Type classType, out string code)
+        {
+            bool wasCodeGenerated = false; // flag indicating whether some code was generated or not
+            string classContent = "";      // store what the contents of the class file is
+
+            // loop through all instanced members of the class and if it's members do contain the
+            // attribute [StaticAccess] then we make add a public static accessor for that member
+            var members = classType.GetMembers(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            foreach (var member in members)
+            {
+                // early return if no [StaticAccess] attribute found
+                var staticAccessAttribute = member.GetCustomAttribute<StaticAccessAttribute>();
+                if (staticAccessAttribute is null) { continue; }
+
+                // figure out the variable name
+                var variableName = staticAccessAttribute.VariableName;
+                if (variableName is null)
+                {
+                    // since no specific variable name is given, it must be auto generated
+                    variableName = member.Name;
+
+                    // a naming scheme is specified in the attribute declaration, which requires an
+                    // underscore for the auto generation to work
+                    if (!variableName.Contains("_"))
+                    {
+                        Debug.LogWarning($"Skipped generating static accessor for {classType.Name}.{member.Name}: " +
+                            $"The member name must contain some leading underscore for name to be autogenerated. " +
+                            $"Please pass a string as a variable name to [StaticAccess(varname)] if you don't want " +
+                            $"the name to be autogenerated.\n");
+
+                        continue;
+                    }
+
+                    // remove anything before the first underscore and capitalize the first character
+                    variableName = variableName.Substring(variableName.IndexOf('_') + 1);
+                    variableName = char.ToUpper(variableName[0]) + variableName.Substring(1);
+                }
+
+
+                // based on the member type, the public accessor's syntax varies
+                if (member.MemberType == MemberTypes.Field)
+                {
+                    var fieldInfo = member as FieldInfo;
+                    classContent += $"public static {fieldInfo.FieldType.FullName} {variableName} => Instance.{member.Name};\n";
+                }
+                else if (member.MemberType == MemberTypes.Property)
+                {
+                    var propertyInfo = member as PropertyInfo;
+                    classContent += $"public static {propertyInfo.PropertyType.FullName} {variableName} => Instance.{member.Name};\n";
+                }
+                else if (member.MemberType == MemberTypes.Method)
+                {
+                    var methodInfo = member as MethodInfo;
+
+                    // stores any formal/actual parameters
+                    string formalParameters = "";
+                    string actualParameters = "";
+
+                    // decipher what the formal and actual parameters of this function are (if any)
+                    var parameters = methodInfo.GetParameters();
+                    foreach(var parameter in parameters)
+                    {
+                        formalParameters += $"{parameter.ParameterType} {parameter.Name}, ";
+                        actualParameters += $"{parameter.Name}, ";
+                    }
+
+                    // remove the trailing comma character from the parameters
+                    if(parameters.Length > 0)
+                    {
+                        formalParameters = formalParameters.Substring(0, formalParameters.LastIndexOf(','));
+                        actualParameters = actualParameters.Substring(0, actualParameters.LastIndexOf(','));
+                    }
+
+                    // string that all together
+                    classContent += $"public static {methodInfo.ReturnType.FullName} {variableName}({formalParameters}) => Instance.{member.Name}({actualParameters});\n";
+                }
+
+                // update the flag letting the system know that some valid code was indeed generated
+                wasCodeGenerated = true;
+            }
+
+            // when no code was generated, either because there were no [StaticAccess] attributes
+            // or the user wanted to have an autogenerated variable name without a leading
+            // underscore, we want to perform an early exit
+            if(!wasCodeGenerated) 
+            {
+                code = "";
+                return false; 
+            }
+
+            // stores the generated code for just the class
+            string classCode = "";
+
+            // classes can either be public or internal, and if there's no access modifier present,
+            // it'll be considered to be internal
+            if (classType.IsPublic)
+            {
+                classCode += "public ";
+            }
+
+            // add the class defenition
+            classCode += $"partial class {classType.Name} : {classType.GetSingletonBaseName()} \n" +
+                          "{ \n" +
+                         $"{classContent}" +
+                          "} \n" ;
+
+            // the overall code that's generated needs to be put together
+            code = "// this code is automatically generated by the Hibzz.Singletons package\n\n";
+            code += "using Hibzz.Singletons;\n\n";
+            if (!string.IsNullOrWhiteSpace(classType.Namespace))
+            {
+                code += $"namespace {classType.Namespace} \n" +
+                         "{ \n" +
+                        $"{classCode}" +
+                         "} \n";
+            }
+            else
+            {
+                code += classCode;
+            }
+
+            return true; // code was indeed generated
+        }
+    }
+
+    internal static class TypeExtensions
+    {
+        /// <summary>
+        /// Alternative version of <see cref="Type.IsSubclassOf"/> that supports raw generic types (generic types without
+        /// any type parameters).
+        /// </summary>
+        /// <param name="baseType">The base type class for which the check is made.</param>
+        /// <param name="toCheck">To type to determine for whether it derives from <paramref name="baseType"/>.</param>
+        /// <remarks>
+        /// Credits to Denis Doomen (https://github.com/dennisdoomen)
+        /// </remarks>
+        public static bool IsSubclassOfRawGeneric(this Type toCheck, Type baseType)
+        {
+            while (toCheck != typeof(object))
+            {
+                Type cur = toCheck.IsGenericType ? toCheck.GetGenericTypeDefinition() : toCheck;
+                if (baseType == cur)
+                {
+                    return true;
+                }
+
+                toCheck = toCheck.BaseType;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Get the base type as a string for a singleton class
+        /// </summary>
+        /// <param name="type">The type of a class that inherits one of the singleton variants</param>
+        /// <returns>A string representation of the base type of the singleton class</returns>
+        public static string GetSingletonBaseName(this Type type)
+        {
+            // we are working with the generic base type
+
+            // when we get the name of a generic base type, c# reflection systems would give us
+            // something of a compiled form... like Singleton`1 but that's not useful for code
+            // generation
+
+            // This is not a general purpose function, it's internal and is very specific to
+            // singletons package... Although it's possible to inherit a class that inherits the
+            // Singleton base class, it's not practical. None of the current class member can be
+            // accessed using the instance property
+
+            // So, we are cutting corners and creating something very specific for the singletons
+            // package that follows the pattern of base<SameType>
+
+            // Issue: When in the future we decide to fix the inheritance issue (if it can be fixed),
+            // we need to revisit this function to be general purpose
+
+            string generic_base = type.BaseType.Name;
+            generic_base = generic_base.Substring(0, generic_base.IndexOf('`'));
+
+            return $"{generic_base}<{type.Name}>";
+        }
+
+        /// <summary>
+        /// check if the given type is on off the singleton variants
+        /// </summary>
+        /// <param name="type">The type to check</param>
+        /// <returns>Is the given type on off the variants of the singleton</returns>
+        public static bool IsASingletonVariant(this Type type)
+        {
+            if (type.IsSubclassOfRawGeneric(typeof(Singleton<>))) { return true; }
+            if (type.IsSubclassOfRawGeneric(typeof(ScriptableSingleton<>))) { return true; }
+
+            return false;
+        }
+    }
+}

--- a/Editor/StaticAccess.cs
+++ b/Editor/StaticAccess.cs
@@ -1,3 +1,5 @@
+#if !DISABLE_SINGLETON_AUTO_PUBLIC_STATIC_ACCESSOR
+
 using System;
 using System.IO;
 using System.Reflection;
@@ -300,3 +302,5 @@ namespace Hibzz.Singletons.Editor
         }
     }
 }
+
+#endif

--- a/Editor/StaticAccess.cs
+++ b/Editor/StaticAccess.cs
@@ -8,14 +8,15 @@ namespace Hibzz.Singletons.Editor
 {
     public class StaticAccess : AssetPostprocessor
     {
+        const string STATIC_ACCESS_PAUSE_KEY = "Hibzz/Singletons/Pause Automatic Code Generation";
+
         // gets a notification after all asset has been imported
-        private static void OnPostprocessAllAssets(
-            string[] importedAssets,
-            string[] deletedAssets,
-            string[] movedAssets,
-            string[] movedFromAssetPaths
-            )
+        private static void OnPostprocessAllAssets(string[] importedAssets, string[] deletedAssets, 
+            string[] movedAssets, string[] movedFromAssetPaths)
         {
+            // if the user wants to pause the automatic code generation of this system, dont proceed
+            if(Menu.GetChecked(STATIC_ACCESS_PAUSE_KEY)) { return; }
+
             // flag that indicates if code has been generated
             bool codeGenerated = false;
 
@@ -218,6 +219,13 @@ namespace Hibzz.Singletons.Editor
             }
 
             return true; // code was indeed generated
+        }
+
+        [MenuItem(STATIC_ACCESS_PAUSE_KEY)]
+        private static void OnStaticAccessPauseMenuPressed()
+        {
+            // this should toggle the Automatic Code Generation
+            Menu.SetChecked(STATIC_ACCESS_PAUSE_KEY, !Menu.GetChecked(STATIC_ACCESS_PAUSE_KEY));
         }
     }
 

--- a/Editor/StaticAccess.cs.meta
+++ b/Editor/StaticAccess.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 00e98f7fdbde32543a16f3d72deafd68
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,27 @@ Debug.Log($"Number of Live NPC's in scene: {_currentNPCCount}");
 <br>
 
 ### Scriptable Singletons
-This package includes support for `ScriptableSingleton`s. 
+This package includes support for `ScriptableSingleton`s. These are Singletons that exists as a ScriptableObject asset in the Resources folder. This allows a Scriptable Singleton to be accessed from anywhere in the project without having to be in the scene.
 
-Scriptable Singleton objects can be automatically created when the class is tagged with the `CreateScriptableSingletonAsset` attribute and the "Create Scriptable Singleton Asset" menu item is selected from the "Hibzz/Singletons" menu.
+Moreover, these objects can be automatically created when the class is tagged with the `[CreateScriptableSingletonAsset]` attribute and the "Create Scriptable Singleton Asset" menu item is selected from the "Hibzz/Singletons" menu.
+
+<br>
+
+### [StaticAccess] Attribute
+The Singletons package comes with a powerful tool for accessing instanced members of a Singleton class without the `Instance` field. This is done by tagging the member with a `[StaticAccess]` attribute.
+
+```csharp
+// defining the singleton
+public partial class AIManager : Singleton<AIManager>
+{
+    [StaticAccess] int _liveNPCCount;
+}
+
+// Accessing the member
+var npcCount = AIManager.LiveNPCCount;
+```
+
+<br>
 
 Learn more about this package in the [documentation](https://docs.hibzz.games/singletons/getting-started/).
 
@@ -46,4 +64,3 @@ Learn more about this package in the [documentation](https://docs.hibzz.games/si
 If you have any questions or want to contribute, feel free to join the [Discord server](https://discord.gg/YXdJ8cZngB) or [Twitter](https://twitter.com/hibzzgames). I'm always looking for feedback and ways to improve this tool. Thanks!
 
 Additionally, you can support the development of these open-source projects via [GitHub Sponsors](https://github.com/sponsors/sliptrixx) and gain early access to the projects.
-

--- a/Scripts/Attributes/StaticAccessAttribute.cs
+++ b/Scripts/Attributes/StaticAccessAttribute.cs
@@ -1,11 +1,9 @@
+#if !DISABLE_SINGLETON_AUTO_PUBLIC_STATIC_ACCESSOR
+
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 
 namespace Hibzz.Singletons
-{
-    
+{    
     public class StaticAccessAttribute : Attribute 
     {
         public string VariableName { get; protected set; } = null;
@@ -44,3 +42,5 @@ namespace Hibzz.Singletons
         }
     }
 }
+
+#endif

--- a/Scripts/Attributes/StaticAccessAttribute.cs
+++ b/Scripts/Attributes/StaticAccessAttribute.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Hibzz.Singletons
+{
+    
+    public class StaticAccessAttribute : Attribute 
+    {
+        public string VariableName { get; protected set; } = null;
+
+        /// <summary>
+        /// Exposes contents inside a partial singleton class through a public 
+        /// static interface using the instance property
+        /// </summary>
+        /// <remarks>
+        /// Without a variable name passed to the attribute, the system will 
+        /// attempt to autogenerate the variable name. Currently the naming 
+        /// schemes available are as follows:
+        /// <list type="number">
+        /// <item>
+        /// Must start with an underscore: For example, <c>_health</c> will have a new public static accessor <c>Health</c>
+        /// </item>
+        /// <item>
+        /// Must contain an underscore: For example, <c>p_mana</c> will have a new public static accessor <c>Mana</c>
+        /// </item>
+        /// </list>
+        /// 
+        /// <i>If things aren't working as expected, please file a bug report in GitHub Issues</i>
+        /// </remarks>
+        public StaticAccessAttribute() { }
+
+        /// <summary>
+        /// Exposes contents inside a partial singleton class through a public static accessor
+        /// </summary>
+        /// <param name="variableName">
+        /// The variable name to set for the new public accessor.
+        /// <para><i>Make sure that the variable name is unique</i></para>
+        /// </param>
+        public StaticAccessAttribute(string variableName) 
+        {
+            VariableName = variableName;
+        }
+    }
+}

--- a/Scripts/Attributes/StaticAccessAttribute.cs.meta
+++ b/Scripts/Attributes/StaticAccessAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d1be4f7a59f001a45aca27ab3fbdb34a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.hibzz.singletons",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "displayName": "hibzz.singletons",
   "description": "A library of singletons for Unity",
   "author": {


### PR DESCRIPTION
### Brief

This update adds a new utility to the `Singletons` package known as `StaticAccess`. Marking any properties, fields, or methods inside a partial singleton class will automatically generate code to make the member accessible via a public static accessor.

### Example Usage

For example,
```csharp
// declaration
public class PrefabManager : Singleton<PrefabManager>
{
    [StaticAccess] GameObject _playerPrefab;
}

// usage
var gameobject = PrefabManager.PlayerPrefab;
```

<br>

Optionally, users can set what their preferred variable name for statically accessing the content must be.
```csharp
// declaration
[StaticAccess("Player_Prefab")] GameObject playerPrefab;

// usage
if(PrefabManager.Player_Prefab == PrefabManager.Instance.playerPrefab)
{
    // always reaches here because it's a shorthand
}
```

### Disabling this feature

This is all possible thanks to code generation. When this feature is used, you'll notice that a new script file is generated with the name `*original_script*.generated.cs` which contains these easily accessible static accessors. This automatic generation can be temporarily paused from the button under `Hibzz > Singletons > Pause Automatic Code Generation`.

On the other hand, if you don't want to use this system, it can be disabled using the following Scriptable Define:
```
DISABLE_SINGLETON_AUTO_PUBLIC_STATIC_ACCESSOR
```

This package has a neat integration with the [Hibzz.DefineManager](https://github.com/hibzzgames/Hibzz.DefineManager) that makes the enabling/disabling of scriptable defines a breeze.